### PR TITLE
Update nl.json - Saved = bewaard not gered.

### DIFF
--- a/src/lang/nl.json
+++ b/src/lang/nl.json
@@ -1905,7 +1905,7 @@
   "Save": "Opslaan",
   "Save As": "Opslaan als",
   "Save this filter": "Bewaar dit filter",
-  "Saved": "Gered",
+  "Saved": "Bewaard",
   "Scale": "Schaal",
   "Scale starts at zero": "Schaal begint bij nul",
   "Screenshot": "Screenshot",


### PR DESCRIPTION
Fixed minor auto-translation issue. "To save" in Dutch can be different: "To save a life" = (redden) or "to safe a file" =(bewaren).